### PR TITLE
rpc: GetBlock with blockID interface

### DIFF
--- a/rpc/block.go
+++ b/rpc/block.go
@@ -155,9 +155,10 @@ type BlockMetadata struct {
 
 // GetBlock returns information about a Tezos block
 // https://tezos.gitlab.io/mainnet/api/rpc.html#get-block-id
-func (c *Client) GetBlock(ctx context.Context, blockID tezos.BlockHash) (*Block, error) {
+func (c *Client) GetBlock(ctx context.Context, blockID interface{}) (*Block, error) {
 	var block Block
-	u := fmt.Sprintf("chains/%s/blocks/%s", c.ChainID, blockID)
+
+	u := fmt.Sprintf("chains/%s/blocks/%s", c.ChainID, GetBlockIDAsString(blockID))
 	if err := c.Get(ctx, u, &block); err != nil {
 		return nil, err
 	}

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Blockwatch Data Inc.
+// Author:
+//
+
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"blockwatch.cc/tzgo/tezos"
+)
+
+func TestGetBlock(t *testing.T) {
+	c, _ := NewClient("https://mainnet-tezos.giganode.io", nil)
+	ctx := context.TODO()
+
+	// GetBlock with BlockHash as parameter
+	resBlock, err := c.GetBlock(ctx, tezos.MustParseBlockHash("BLxneVqo5855NK2gqdsGmMeAPRtgXxyFgncesY5sityY1dUbDcM"))
+	if err != nil {
+		t.Errorf("getblock error: %v", err)
+	}
+	if resBlock.Hash.String() != "BLxneVqo5855NK2gqdsGmMeAPRtgXxyFgncesY5sityY1dUbDcM" {
+		t.Error("GetBlock error. See log for details")
+		t.FailNow()
+	}
+
+	// GetBlock with block level (int64) as parameter
+	var blockLevel int64 = 121212
+	resBlock, err = c.GetBlock(ctx, blockLevel)
+	if err != nil {
+		t.Errorf("getblock error: %v", err)
+	}
+	if resBlock.Hash.String() != "BLxneVqo5855NK2gqdsGmMeAPRtgXxyFgncesY5sityY1dUbDcM" {
+		t.Error("GetBlock error. See log for details")
+		t.FailNow()
+	}
+
+	// GetBlock with block tag "genesis"
+	resBlock, err = c.GetBlock(ctx, "genesis")
+	if err != nil {
+		t.Errorf("getblock error: %v", err)
+	}
+	if resBlock.Hash.String() != "BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2" {
+		t.Error("GetBlock error. See log for details")
+		t.FailNow()
+	}
+
+}

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -8,6 +8,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
+	"blockwatch.cc/tzgo/tezos"
 )
 
 // HexBytes represents bytes as a JSON string of hexadecimal digits
@@ -94,4 +97,23 @@ func jsonify(i interface{}) string {
 		log.Fatal(err)
 	}
 	return string(jsonb)
+}
+
+func GetBlockIDAsString(blockID interface{}) string {
+	switch v := blockID.(type) {
+	case tezos.BlockHash:
+		return blockID.(tezos.BlockHash).String()
+	case int64:
+		return strconv.FormatInt(blockID.(int64), 10)
+	case string:
+		if blockID.(string) == "head" {
+			return "head"
+		} else if blockID.(string) == "genesis" {
+			return "genesis"
+		} else {
+			return fmt.Sprintf("Block tag %s not supported.\n", v)
+		}
+	default:
+		return fmt.Sprintf("Type %s not supported as block identifier.\n", v)
+	}
 }


### PR DESCRIPTION
Change to support block tags, block level, and block hashs in
GetBlock function.

Signed-off-by: sebeec <beeclearo@protonmail.com>