### PR TITLE
Add method to expose token uri

### DIFF
--- a/contract/token.go
+++ b/contract/token.go
@@ -129,6 +129,10 @@ func (t *TokenMetadata) UnmarshalPrim(prim micheline.Prim) error {
 	})
 }
 
+func (t *TokenMetadata) URI() string {
+	return t.uri
+}
+
 func ResolveTokenMetadata(ctx context.Context, contract *Contract, tokenid tezos.Z) (*TokenMetadata, error) {
 	var (
 		store micheline.Prim


### PR DESCRIPTION
Having access to the token URI is useful when we don't want to resolve the token metadata, but only retrieve the URI for it. Having it be read-only is understandable, but having it completely hidden from public access seems needlessly restrictive.