### PR TITLE
Fix operation fee estimation

### DIFF
--- a/codec/utils.go
+++ b/codec/utils.go
@@ -7,6 +7,7 @@ import (
     "bytes"
     "fmt"
     "io"
+    "math"
 
     "blockwatch.cc/tzgo/tezos"
 )
@@ -29,7 +30,7 @@ func CalculateMinFee(o Operation, gas int64, withHeader bool, p *tezos.Params) i
         sz += 32 + 64 // branch + signature
     }
     fee := minFeeFixedNanoTez + sz*minFeeByteNanoTez + gas*minFeeGasNanoTez
-    return fee / 1000 // nano -> micro
+    return int64(math.Ceil(float64(fee) / 1000)) // nano -> micro, round up
 }
 
 // ensureTagAndSize reads the binary operation's tag and matches it against the expected


### PR DESCRIPTION
This commit adds an iteration in the operation fee estimation, to take into account the impact of the fee value in the operation size.
It also rounds up the computed fee, when converting nano tez into micro tez.
