### PR TITLE
Ensure hashval is reset in observer if match fails.

### DIFF
--- a/rpc/observer.go
+++ b/rpc/observer.go
@@ -238,12 +238,12 @@ func (m *Observer) listenBlocks() {
 				// match op hash against registry
 				hashval.Write(h.Hash.Hash)
 				id, ok := m.hashmap[hashval.Sum64()]
+				hashval.Reset()
 				if !ok {
 					log.Debugf("monitor: --- !! %s", h)
 					continue
 				}
 				match, ok := m.registry[id]
-				hashval.Reset()
 				if !ok {
 					log.Debugf("monitor: --- !! %s", h)
 					continue


### PR DESCRIPTION
I hit an issue whereby my contract calls and origination attempts would never return. After investigation it turns out the root cause is that the monitor re-uses a hash object when checking operations in each block, but the reset of the hash object was placed such that it only got called if there was success on the first operation hash (subsequent hashes would fail because the hashval variable hadn't been reset).