### PR TITLE
Avoid a panic when multiple operations are returned when watching for origination.

### DIFF
--- a/contract/contract.go
+++ b/contract/contract.go
@@ -364,6 +364,14 @@ func (c *Contract) DeployExt(ctx context.Context, delegate tezos.Address, balanc
 	if !rcpt.IsSuccess() {
 		return nil, rcpt.Error()
 	}
-	c.addr = rcpt.Op.Contents[0].Result().OriginatedContracts[0]
+	for _, contents := range rcpt.Op.Contents {
+		if contents.Kind() == tezos.OpTypeOrigination {
+			result := contents.Result()
+			if len(result.OriginatedContracts) > 0 {
+				c.addr = result.OriginatedContracts[0]
+				break
+			}
+		}
+	}
 	return rcpt, nil
 }


### PR DESCRIPTION
I hit this when testing against the tezos sandbox. The original code assumed that the results returned from watching for a contract deployment would only contain a single result, and made an unsafe array access without checking that this was true.

It looks like in the same block I'm getting both a reveal and origination result. I'm currently not sure why I'm seeing the reveal call there, but regardless, panicking is not a good thing to do, so this change checks for an origination result and if it finds one returns the first address.

Things to consider here: what if there's success but not origination found? Here you'd still return early without a contract address.