### PR TITLE
Set Amount in TxArgs.Encode

### DIFF
--- a/contract/contract.go
+++ b/contract/contract.go
@@ -60,6 +60,7 @@ func (a *TxArgs) Encode() *codec.Transaction {
 		Manager: codec.Manager{
 			Source: a.Source,
 		},
+		Amount:      a.Amount,
 		Destination: a.Destination,
 		Parameters:  &a.Params,
 	}


### PR DESCRIPTION
Amount was ignored when encoding TxArgs, making it impossible to use non-zero Amount when using `Contract.Call`.

Signed-off-by: Jean Schmitt <github@jeanschmitt.fr>