### PR TITLE
Re-initialize the constants for startHeight and startCycle for GetParams

### DIFF
--- a/rpc/constants.go
+++ b/rpc/constants.go
@@ -80,7 +80,12 @@ func (c *Client) GetParams(ctx context.Context, id BlockID) (*tezos.Params, erro
 		WithProtocol(meta.Protocol).
 		WithNetwork(ver.NetworkVersion.ChainName)
 
-	if ver.NetworkVersion.ChainName == "TEZOS_MAINNET" {
+	// Re-initialize for StartHeight and StartCycle for MAINNET
+	block, err := c.GetBlock(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if ver.NetworkVersion.ChainName == "TEZOS_MAINNET" && block.Header.Level >= tezos.DefaultParams.StartHeight-1 {
 		p.StartHeight = tezos.DefaultParams.StartHeight
 		p.StartCycle = tezos.DefaultParams.StartCycle
 	}

--- a/rpc/constants.go
+++ b/rpc/constants.go
@@ -79,6 +79,12 @@ func (c *Client) GetParams(ctx context.Context, id BlockID) (*tezos.Params, erro
 		WithChainId(c.ChainId).
 		WithProtocol(meta.Protocol).
 		WithNetwork(ver.NetworkVersion.ChainName)
+
+	if ver.NetworkVersion.ChainName == "TEZOS_MAINNET" {
+		p.StartHeight = tezos.DefaultParams.StartHeight
+		p.StartCycle = tezos.DefaultParams.StartCycle
+	}
+
 	return p, nil
 }
 

--- a/tezos/param_test.go
+++ b/tezos/param_test.go
@@ -1,9 +1,10 @@
 package tezos_test
 
 import (
+	"testing"
+
 	"blockwatch.cc/tzgo/rpc"
 	"blockwatch.cc/tzgo/tezos"
-	"testing"
 )
 
 type (
@@ -120,6 +121,11 @@ func checkParams(t *testing.T, p *tezos.Params, height, cycle int64, check param
 	if have, want := p.IsSnapshotBlock(height), check.IsSnapshot(); have != want {
 		t.Errorf("v%03d IsSnapshotBlock(%d) mismatch: have=%t want=%t", p.Version, height, have, want)
 	}
+
+	if have, want := p.SnapshotBlock(cycle, check.Snap), snapLevelResults[height]; have != want {
+		t.Errorf("v%03d SnapshotBlock(%d, %d) mismatch: have=%d want=%d", p.Version, cycle, check.Snap, have, want)
+	}
+
 	if have, want := p.SnapshotIndex(height), check.Snap; have != want {
 		t.Errorf("v%03d SnapshotIndex(%d) mismatch: have=%d want=%d", p.Version, height, have, want)
 	}
@@ -149,6 +155,44 @@ func (p paramResult) IsVoteStart() bool {
 
 func (p paramResult) IsVoteEnd() bool {
 	return p.Flags&0x1 > 0
+}
+
+var snapLevelResults = map[int64]int64{
+	0:       0,       // genesis
+	1:       0,       // bootstrap
+	2:       0,       // v001 start
+	28082:   0,       // ---> end
+	28083:   0,       // v002 start
+	204761:  175871,  // ---> end
+	204762:  175871,  // v003 start
+	458752:  430080,  // ---> end
+	458753:  430080,  // v004 start
+	655360:  626688,  // ---> end
+	655361:  626688,  // v005 start
+	851968:  823296,  // ---> end
+	851969:  823296,  // v006 start
+	1212416: 1183744, // ---> end
+	1212417: 1183744, // v007 start
+	1343488: 1314816, // ---> end
+	1343489: 1314816, // v008 start Edo Bug
+	1466367: 1437440, // ---> end (proto end, vote end, !cycle end)
+	1466368: 1437696, // v009 start (proto start, vote start, cycle end)
+	1466369: 1437696, // v009 cycle start
+	1589247: 1560320, // --> end (proto end, vote end, !cycle end)
+	1589248: 1564672, // v010 start (proto start, vote start, cycle end)
+	1589249: 1560576, // v010 cycle start
+	1916928: 1859584, // --> end
+	1916929: 1859584, // v011 start
+	2244608: 2187264, // --> end
+	2244609: 2195456, // v012 start
+	2490368: 2441216, // --> end
+	2490369: 2441216, // v013 start
+	2736128: 2686976, // --> end
+	2736129: 2686976, // v014 start
+	2981888: 2932736, // --> end
+	2981889: 2932736, // v015 start
+	3268608: 3219456, // --> end
+	3268609: 3219456, // v016 start
 }
 
 var paramResults = map[int64]paramResult{

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -206,6 +206,9 @@ func (p Params) ContainsCycle(c int64) bool {
 	if c == 387 && p.IsMainnet() {
 		s--
 	}
+	if s == 0 {
+		return false
+	}
 	return s <= c
 }
 

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -28,6 +28,8 @@ var (
 		PreservedCycles:              5,
 		BlocksPerCycle:               16384,
 		BlocksPerSnapshot:            1024,
+		StartHeight:                  3268609,
+		StartCycle:                   593,
 	}
 
 	// GhostnetParams defines the blockchain configuration for Ghostnet testnet.
@@ -205,9 +207,6 @@ func (p Params) ContainsCycle(c int64) bool {
 	s := p.StartCycle
 	if c == 387 && p.IsMainnet() {
 		s--
-	}
-	if s == 0 {
-		return false
 	}
 	return s <= c
 }


### PR DESCRIPTION
We uses SnapshotBlock from tzgo library to get the snapshot block for rewards.
v1.15.2 SnapshotBlock `3219456` for Block Height `2168608`
v1.16.5  SnapshotBlock `9617407` for Block Height  `2168608`

For function AtCycle ([Link](https://github.com/blockwatch-cc/tzgo/blob/master/tezos/params.go#L175)), which is called at very beginning of CycleStartHeight .

AtCycle firstly checks if params contains currency passed in Cycle. After Mumbai's upgrade, the p.StartCycle is always not loaded correctly thus giving 0, that causes problem of showing wrong `snap level` later on when we are using it to get params for certain blocks after 592nd cycle. So I added a check in the GetParams function when it is in Mainnet, we just re initialize the StartHeight and StartCycle again so that it will calculate the `snap level` normally.

Any inputs will be appreciated