### PR TITLE
Add an option to get RPC Client Interface instead of Structure

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -54,6 +54,13 @@ type Client struct {
 	MetadataMode MetadataMode
 }
 
+// NewClient returns a new Tezos RPC client as an interface
+// Allows to change client implementations and mock them
+// Recommended to use instead of "NewClient"
+func NewRPCClient(baseURL string, httpClient *http.Client) (RpcClient, error) {
+	return NewClient(baseURL, httpClient)
+}
+
 // NewClient returns a new Tezos RPC client.
 func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
 	if httpClient == nil {
@@ -103,6 +110,10 @@ func (c *Client) UseIpfsUrl(uri string) error {
 
 func (c *Client) Client() *http.Client {
 	return c.client
+}
+
+func (c *Client) RpcClient() *Client {
+	return c
 }
 
 func (c *Client) Listen() {

--- a/rpc/interface.go
+++ b/rpc/interface.go
@@ -18,6 +18,7 @@ type RpcClient interface {
 	Init(ctx context.Context) error
 	UseIpfsUrl(uri string) error
 	Client() *http.Client
+	RpcClient() *Client
 	Listen()
 	Close()
 	ResolveChainConfig(ctx context.Context) error


### PR DESCRIPTION
Hi 👋 

Continuation of https://github.com/blockwatch-cc/tzgo/pull/43
Started to add unit tests and use mocks and found out that we return instance of the RPC client instead of interface.
So I didn't modify the "NewClient" method for backward compatibility, but added additional one, which is more preferable to use for new users.
